### PR TITLE
Removing the Microsoft.Orleans.OrleansProviders dependency

### DIFF
--- a/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
+++ b/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="Aerospike.Client" Version="3.9.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
+++ b/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.2.60" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="Aerospike.Client" Version="3.9.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/test/Orleans.Aerospike.Tests/Orleans.Aerospike.Tests.csproj
+++ b/test/Orleans.Aerospike.Tests/Orleans.Aerospike.Tests.csproj
@@ -13,7 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Heya! This is simply removing the explicit `Microsoft.Orleans.OrleansProviders` dependency from the project, as it doesn't seem to be required.

---

For a bit of background: I was just upgrading Orleans to the latest 4.0 preview 1 (a breaking major change) and ended up receiving this error:

> [CS7069] Reference to type 'ISiloHostBuilder' claims it is defined in 'Orleans.Runtime.Abstractions', but it could not be found

The problem appears to be that `Microsoft.Orleans.OrleansRuntime` is pinned to the exact `4.0.0-preview1` through my own project, but `Microsoft.Orleans.OrleansProviders` is left dangling at `3.3.0`; its own dependencies are then upgraded to `4.0.0-preview1` again, resulting in this error.

![image](https://user-images.githubusercontent.com/495335/155539098-64965ad5-a900-46f7-92d3-33df3dc837fb.png)

Removing the dependency may not solve the issue entirely, but it should at least get that specific bit out of the way. 🙂