### PR TITLE
Structured logging and fragments

### DIFF
--- a/src/Orleans.Clustering.Aerospike/AerospikeMembershipTable.cs
+++ b/src/Orleans.Clustering.Aerospike/AerospikeMembershipTable.cs
@@ -39,7 +39,7 @@ namespace Orleans.Clustering.Aerospike
                 }
                 catch(Exception exp)
                 {
-                    _logger.LogError(exp, "Truncate failed. {0} {1} {2} ", _options.Namespace, _options.SetName, beforeDate);
+                    _logger.LogError(exp, "Truncate failed: {Namespace} {SetName} {BeforeDate}", _options.Namespace, _options.SetName, beforeDate);
                     throw;
                 }
             });
@@ -96,7 +96,7 @@ namespace Orleans.Clustering.Aerospike
             }
             catch(Exception exp)
             {
-                _logger.LogError(exp, "Insert MembershipEntry failed.");
+                _logger.LogError(exp, "Insert MembershipEntry failed");
                 return false;
             }
         }
@@ -184,7 +184,7 @@ namespace Orleans.Clustering.Aerospike
                        recordExistsAction = RecordExistsAction.UPDATE
                    },
                    Task.Factory.CancellationToken,
-                   new Key(_options.Namespace, _options.SetName, siloid), 
+                   new Key(_options.Namespace, _options.SetName, siloid),
                    new Bin[] { new Bin("iamalivetime", entry.IAmAliveTime.ToBinary()) });
         }
 
@@ -198,7 +198,7 @@ namespace Orleans.Clustering.Aerospike
             }
             catch(Exception exp)
             {
-                _logger.LogError(exp, "Update MembershipEntry failed.");
+                _logger.LogError(exp, "Update MembershipEntry failed");
                 return false;
             }
         }
@@ -234,10 +234,10 @@ namespace Orleans.Clustering.Aerospike
                 await _client.Put(
                     new WritePolicy(_clientPolicy.writePolicyDefault)
                     {
-                        sendKey = true, 
-                        recordExistsAction = isUpdate ? RecordExistsAction.UPDATE : RecordExistsAction.CREATE_ONLY 
-                    }, 
-                    Task.Factory.CancellationToken, 
+                        sendKey = true,
+                        recordExistsAction = isUpdate ? RecordExistsAction.UPDATE : RecordExistsAction.CREATE_ONLY
+                    },
+                    Task.Factory.CancellationToken,
                     new Key(_options.Namespace, _options.SetName, siloid), bins);
             }
             else
@@ -247,10 +247,10 @@ namespace Orleans.Clustering.Aerospike
                     {
                         sendKey = true,
                         recordExistsAction = isUpdate ? RecordExistsAction.UPDATE : RecordExistsAction.CREATE_ONLY,
-                        generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL, 
+                        generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL,
                         generation = int.Parse(etag)
-                    }, 
-                    Task.Factory.CancellationToken, 
+                    },
+                    Task.Factory.CancellationToken,
                     new Key(_options.Namespace, _options.SetName, siloid), bins);
             }
         }
@@ -270,8 +270,8 @@ namespace Orleans.Clustering.Aerospike
             else
             {
                 await _client.Put(
-                    new WritePolicy() { sendKey = true, generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL, generation = int.Parse(version.VersionEtag) }, 
-                    Task.Factory.CancellationToken, 
+                    new WritePolicy() { sendKey = true, generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL, generation = int.Parse(version.VersionEtag) },
+                    Task.Factory.CancellationToken,
                     new Key(_options.Namespace, _options.SetName, id), bins);
             }
         }

--- a/src/Orleans.Persistence.Aerospike/AerospikeGrainStorage.cs
+++ b/src/Orleans.Persistence.Aerospike/AerospikeGrainStorage.cs
@@ -45,7 +45,8 @@ namespace Orleans.Persistence.Aerospike
 
         public async Task Init(CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Init host={_options.Host} port={_options.Port} ns:{_options.Namespace} serializer={_aerospikeSerializer.GetType().Name}");
+            _logger.LogInformation("Init host={Host} port={Port} ns:{Namespace} serializer={SerializerName}",
+                _options.Host, _options.Port, _options.Namespace, _aerospikeSerializer.GetType().Name);
 
             _clientPolicy = new AsyncClientPolicy()
             {
@@ -65,7 +66,7 @@ namespace Orleans.Persistence.Aerospike
             };
 
             Log.SetLevel(Log.Level.INFO);
-            Log.SetCallback((level, message) => 
+            Log.SetCallback((level, message) =>
             {
                 LogLevel logLevel = LogLevel.None;
                 switch(level)
@@ -83,11 +84,11 @@ namespace Orleans.Persistence.Aerospike
                         logLevel = LogLevel.Warning;
                         break;
                 }
-                _logger.Log(logLevel, "Aerospike-Message: " + message);
+                _logger.Log(logLevel, "Aerospike-Message: {Message}", message);
             });
 
             _client = new AsyncClient(_clientPolicy,
-                _options.Host, 
+                _options.Host,
                 _options.Port);
         }
 
@@ -108,12 +109,12 @@ namespace Orleans.Persistence.Aerospike
             }
             catch (AerospikeException aep)
             {
-                _logger.LogError(aep, $"Failure clearing state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
+                _logger.LogError(aep, "Failure clearing state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
                 throw new AerospikeOrleansException(aep.Message);
             }
             catch (Exception exp)
             {
-                _logger.LogError(exp, $"Failure clearing state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
+                _logger.LogError(exp, "Failure clearing state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
             }
         }
 
@@ -138,12 +139,12 @@ namespace Orleans.Persistence.Aerospike
             }
             catch (AerospikeException aep)
             {
-                _logger.LogError(aep, $"Failure reading state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
+                _logger.LogError(aep, "Failure reading state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
                 throw new AerospikeOrleansException(aep.Message);
             }
             catch (Exception exp)
             {
-                _logger.LogError(exp, $"Failure reading state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
+                _logger.LogError(exp, "Failure reading state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
                 grainState.ETag = null;
                 grainState.RecordExists = true;
             }
@@ -184,12 +185,12 @@ namespace Orleans.Persistence.Aerospike
                     throw new InconsistentStateException($"Generation conflict while writing Grain Type {grainType} with key {grainReference.ToKeyString()}. Error:{aep.Message}",  grainState.ETag, "?");
                 }
 
-                _logger.LogError(aep, $"Failure writing state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
-                throw new AerospikeOrleansException(aep.Message); // simple serializable excepction
+                _logger.LogError(aep, "Failure writing state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
+                throw new AerospikeOrleansException(aep.Message); // simple serializable exception
             }
             catch (Exception exp)
             {
-                _logger.LogError(exp, $"Failure writing state for Grain Type {grainType} with key {grainReference.ToKeyString()}.");
+                _logger.LogError(exp, "Failure writing state for Grain Type {GrainType} with key {GrainKey}", grainType, grainReference.ToKeyString());
                 throw;
             }
         }


### PR DESCRIPTION
Small change to use structured logging and follow the "fragments instead of sentences" best practice ([from here](https://github.com/olsh/resharper-structured-logging/blob/f2da05b2ee93d926f5f07d6692295570bdb69235/rules/LogMessageIsSentenceProblem.md)).