### PR TITLE
Orleans 4.0.0-preview1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ await silo.StartAsync();
 ## Quickstart on Windows
 Aerospike runs only with Linux. Therefore a local development environment on Windows can be setup using WSL2 following the instructions on https://www.aerospike.com/docs/operations/install/linux/ for the Community Edition. To start Aerospike execute ```sudo asd --foreground```.
 
+## Quickstart using Docker Compose
+You can use Docker Compose to start an Aerospike instance by executing ```docker-compose up``` in the repository root directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+version: "3.2"
+
+services:
+  aerospike:
+    image: aerospike/aerospike-server:5.7.0.8
+    command:
+      - "--config-file=/run/secrets/aerospike.conf"
+    secrets:
+      - source: aerospike
+        target: aerospike.conf
+    ports:
+      - "3000:3000/tcp"
+
+secrets:
+  aerospike:
+    file: ./docker/aerospike.conf

--- a/docker/aerospike.conf
+++ b/docker/aerospike.conf
@@ -1,0 +1,65 @@
+# Aerospike database configuration file.
+
+# This stanza must come first.
+service {
+	user root
+	group root
+	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
+	pidfile /var/run/aerospike/asd.pid
+	service-threads 2
+	proto-fd-max 15000
+}
+
+logging {
+	# Log file must be an absolute path.
+	file /var/log/aerospike/aerospike.log {
+		context any info
+	}
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address eth0
+		port 3000
+
+		# Uncomment the following to set the `access-address` parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		address eth0
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		port 3002
+
+		# use asinfo -v 'tip:host=<ADDR>;port=3002' to inform cluster of
+		# other mesh nodes
+
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		address eth0
+		port 3001
+	}
+
+	info {
+		port 3003
+	}
+}
+
+namespace dev {
+	replication-factor 2
+	memory-size 1G
+	default-ttl 0d
+	storage-engine memory
+}

--- a/src/Orleans.Clustering.Aerospike/AerospikeClusteringOptions.cs
+++ b/src/Orleans.Clustering.Aerospike/AerospikeClusteringOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Orleans.Clustering.Aerospike
+﻿namespace Orleans.Clustering.Aerospike
 {
     public class AerospikeClusteringOptions
     {

--- a/src/Orleans.Clustering.Aerospike/AerospikeGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Aerospike/AerospikeGatewayListProvider.cs
@@ -1,37 +1,32 @@
 ﻿using Aerospike.Client;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Orleans.Clustering.Aerospike
 {
-    public class AerospikeGatewayListProvider : IGatewayListProvider
+    public class AerospikeGatewayListProvider : IGatewayListProvider, IDisposable
     {
-        private TimeSpan _maxStalness;
         private bool _isUpdated;
-        private string _clusterId;
-        private TimeSpan _maxStaleness;
-        private ILoggerFactory _loggerFactory;
-        private AerospikeGatewayOptions _options;
+        private readonly string _clusterId;
+        private readonly TimeSpan _maxStaleness;
+        private readonly AerospikeGatewayOptions _options;
         private AsyncClientPolicy _clientPolicy;
         private AsyncClient _client;
 
-        public TimeSpan MaxStaleness => _maxStalness;
+        public TimeSpan MaxStaleness => _maxStaleness;
 
         public bool IsUpdatable => _isUpdated;
 
-        public AerospikeGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AerospikeGatewayOptions> options,
+        public AerospikeGatewayListProvider(IOptions<AerospikeGatewayOptions> options,
             IOptions<ClusterOptions> clusterOptions, IOptions<GatewayOptions> gatewayOptions)
         {
             _clusterId = clusterOptions.Value.ClusterId;
             _maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
-            _loggerFactory = loggerFactory;
             _options = options.Value;
         }
 
@@ -77,6 +72,12 @@ namespace Orleans.Clustering.Aerospike
 
                 _client = new AsyncClient(_clientPolicy, _options.Host, _options.Port);
             });
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _client.Dispose();
         }
     }
 }

--- a/src/Orleans.Clustering.Aerospike/AerospikeGatewayOptions.cs
+++ b/src/Orleans.Clustering.Aerospike/AerospikeGatewayOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Orleans.Clustering.Aerospike
+﻿namespace Orleans.Clustering.Aerospike
 {
     public class AerospikeGatewayOptions
     {

--- a/src/Orleans.Clustering.Aerospike/AerospikeHostingExtensions.cs
+++ b/src/Orleans.Clustering.Aerospike/AerospikeHostingExtensions.cs
@@ -5,34 +5,11 @@ using Orleans.Clustering.Aerospike;
 using Orleans.Hosting;
 using Orleans.Messaging;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Extensions.Hosting
 {
     public static class AerospikeHostingExtensions
     {
-        public static ISiloHostBuilder UseAerospikeMembership(this ISiloHostBuilder builder,
-           Action<AerospikeClusteringOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAerospikeMembership(configureOptions));
-        }
-
-        public static ISiloHostBuilder UseAerospikeMembership(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<AerospikeClusteringOptions>> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAerospikeMembership(configureOptions));
-        }
-
-        public static ISiloHostBuilder UseAerospikeMembership(this ISiloHostBuilder builder)
-        {
-            return builder.ConfigureServices(services =>
-            {
-                services.AddOptions<AerospikeClusteringOptions>();
-                services.AddSingleton<IMembershipTable, AerospikeMembershipTable>();
-            });
-        }
-
         public static ISiloBuilder UseAerospikeMembership(this ISiloBuilder builder,
            Action<AerospikeClusteringOptions> configureOptions)
         {

--- a/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
+++ b/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
     <PackageReference Include="Aerospike.Client" Version="3.9.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
+++ b/src/Orleans.Clustering.Aerospike/Orleans.Clustering.Aerospike.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
-    <PackageReference Include="Aerospike.Client" Version="3.9.10" />
+    <PackageReference Include="Aerospike.Client" Version="4.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Orleans.Persistence.Aerospike/AerospikeGrainStorageFactory.cs
+++ b/src/Orleans.Persistence.Aerospike/AerospikeGrainStorageFactory.cs
@@ -3,8 +3,6 @@ using Microsoft.Extensions.Options;
 using Orleans.Persistence.Aerospike;
 using Orleans.Storage;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Orleans.Persistence
 {

--- a/src/Orleans.Persistence.Aerospike/AerospikeHostingExtensions.cs
+++ b/src/Orleans.Persistence.Aerospike/AerospikeHostingExtensions.cs
@@ -10,8 +10,6 @@ using Orleans.Persistence.Aerospike;
 using Orleans.Runtime;
 using Orleans.Storage;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Orleans.Persistence.Aerospike.Serializer;
 
 namespace Microsoft.Extensions.Hosting
@@ -21,38 +19,6 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public static class AeorpspikeHostingExtensions
     {
-        /// <summary>
-        /// Adds a Aerospike grain storage provider as the default provider
-        /// </summary>
-        public static ISiloHostBuilder AddAerospikeGrainStorageAsDefault(this ISiloHostBuilder builder, Action<AerospikeStorageOptions> configureOptions)
-        {
-            return builder.AddAerospikeGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Adds a Aerospike grain storage provider.
-        /// </summary>
-        public static ISiloHostBuilder AddAerospikeGrainStorage(this ISiloHostBuilder builder, string name, Action<AerospikeStorageOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.AddAerospikeGrainStorage(name, configureOptions));
-        }
-
-        /// <summary>
-        /// Adds a Aerospike grain storage provider as the default provider
-        /// </summary>
-        public static ISiloHostBuilder AddAerospikeGrainStorageAsDefault(this ISiloHostBuilder builder, Action<OptionsBuilder<AerospikeStorageOptions>> configureOptions = null)
-        {
-            return builder.AddAerospikeGrainStorage(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, configureOptions);
-        }
-
-        /// <summary>
-        /// Adds a Aerospike grain storage provider.
-        /// </summary>
-        public static ISiloHostBuilder AddAerospikeGrainStorage(this ISiloHostBuilder builder, string name, Action<OptionsBuilder<AerospikeStorageOptions>> configureOptions = null)
-        {
-            return builder.ConfigureServices(services => services.AddAerospikeGrainStorage(name, configureOptions));
-        }
-
         /// <summary>
         /// Adds a Aerospike grain storage provider as the default provider
         /// </summary>

--- a/src/Orleans.Persistence.Aerospike/AerospikeStorageOptions.cs
+++ b/src/Orleans.Persistence.Aerospike/AerospikeStorageOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Orleans.Persistence.Aerospike
+﻿namespace Orleans.Persistence.Aerospike
 {
     public class AerospikeStorageOptions
     {

--- a/src/Orleans.Persistence.Aerospike/AerospikeStorageOptionsValidator.cs
+++ b/src/Orleans.Persistence.Aerospike/AerospikeStorageOptionsValidator.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Orleans.Persistence.Aerospike
+﻿namespace Orleans.Persistence.Aerospike
 {
     internal class AerospikeStorageOptionsValidator : IConfigurationValidator
     {

--- a/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
+++ b/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="4.0.0-preview1" />
-    <PackageReference Include="Aerospike.Client" Version="3.9.10" />
+    <PackageReference Include="Aerospike.Client" Version="4.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   

--- a/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
+++ b/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.2.60" />
+    <PackageReference Include="MessagePack" Version="2.3.85" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="4.0.0-preview1" />

--- a/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
+++ b/src/Orleans.Persistence.Aerospike/Orleans.Persistence.Aerospike.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
@@ -25,10 +25,11 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.2.60" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.Serialization" Version="4.0.0-preview1" />
     <PackageReference Include="Aerospike.Client" Version="3.9.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
 </Project>

--- a/src/Orleans.Persistence.Aerospike/Serializer/AerospikeJsonSerializer.cs
+++ b/src/Orleans.Persistence.Aerospike/Serializer/AerospikeJsonSerializer.cs
@@ -4,26 +4,25 @@ namespace Orleans.Persistence.Aerospike.Serializer
 {
     public class AerospikeJsonSerializer : IAerospikeSerializer
     {
-        public Bin[] Serialize(IGrainState grainState)
+        public Bin[] Serialize<T>(IGrainState<T> grainState)
         {
             var data = Newtonsoft.Json.JsonConvert.SerializeObject(grainState.State);
 
             Bin[] bins = new Bin[]
             {
                 new Bin("data", data),
-                new Bin("type", grainState.Type.Name)
+                new Bin("type", typeof(T).Name)
             };
             return bins;
         }
 
-        public void Deserialize(Record record, IGrainState grainState)
+        public void Deserialize<T>(Record record, IGrainState<T> grainState)
         {
             var data = record.bins["data"].ToString();
-            grainState.State = Newtonsoft.Json.JsonConvert.DeserializeObject(data, grainState.Type);
+            grainState.State = (T)Newtonsoft.Json.JsonConvert.DeserializeObject(data!, typeof(T));
         }
     }
 
 
 
 }
-

--- a/src/Orleans.Persistence.Aerospike/Serializer/AerospikeMessagePackSerializer.cs
+++ b/src/Orleans.Persistence.Aerospike/Serializer/AerospikeMessagePackSerializer.cs
@@ -4,26 +4,25 @@ namespace Orleans.Persistence.Aerospike.Serializer
 {
     public class AerospikeMessagePackSerializer : IAerospikeSerializer
     {
-        public Bin[] Serialize(IGrainState grainState)
+        public Bin[] Serialize<T>(IGrainState<T> grainState)
         {
             var data = MessagePack.MessagePackSerializer.Typeless.Serialize(grainState.State);
 
             Bin[] bins = new Bin[]
             {
                 new Bin("data", data),
-                new Bin("type", grainState.Type.Name)
+                new Bin("type", typeof(T).Name)
             };
             return bins;
         }
 
-        public void Deserialize(Record record, IGrainState grainState)
+        public void Deserialize<T>(Record record, IGrainState<T> grainState)
         {
             var data = record.bins["data"] as byte[];
-            grainState.State = MessagePack.MessagePackSerializer.Typeless.Deserialize(data);
+            grainState.State = (T)MessagePack.MessagePackSerializer.Typeless.Deserialize(data);
         }
     }
 
 
 
 }
-

--- a/src/Orleans.Persistence.Aerospike/Serializer/AerospikeOrleansSerializer.cs
+++ b/src/Orleans.Persistence.Aerospike/Serializer/AerospikeOrleansSerializer.cs
@@ -1,34 +1,32 @@
 ﻿using Aerospike.Client;
-using Orleans.Serialization;
 
 namespace Orleans.Persistence.Aerospike.Serializer
 {
     public class AerospikeOrleansSerializer : IAerospikeSerializer
     {
-        private readonly SerializationManager _serializationManager;
+        private readonly Serialization.Serializer _serializationManager;
 
-        public AerospikeOrleansSerializer(SerializationManager serializationManager)
+        public AerospikeOrleansSerializer(Serialization.Serializer serializationManager)
         {
             _serializationManager = serializationManager;
         }
 
-        public Bin[] Serialize(IGrainState grainState)
+        public Bin[] Serialize<T>(IGrainState<T> grainState)
         {
-            var data = _serializationManager.SerializeToByteArray(grainState.State);
-            
+            var data = _serializationManager.SerializeToArray(grainState.State);
+
             Bin[] bins = new Bin[]
             {
                 new Bin("data", data),
-                new Bin("type", grainState.Type.Name)
+                new Bin("type", typeof(T).Name)
             };
             return bins;
         }
 
-        public void Deserialize(Record record, IGrainState grainState)
+        public void Deserialize<T>(Record record, IGrainState<T> grainState)
         {
             var data = record.bins["data"] as byte[];
-            grainState.State = _serializationManager.DeserializeFromByteArray<object>(data);
+            grainState.State = _serializationManager.Deserialize<T>(data);
         }
     }
 }
-

--- a/src/Orleans.Persistence.Aerospike/Serializer/IAerospikeSerializer.cs
+++ b/src/Orleans.Persistence.Aerospike/Serializer/IAerospikeSerializer.cs
@@ -4,8 +4,7 @@ namespace Orleans.Persistence.Aerospike.Serializer
 {
     public interface IAerospikeSerializer
     {
-        Bin[] Serialize(IGrainState grainState);
-        void Deserialize(Record record, IGrainState grainState);
+        Bin[] Serialize<T>(IGrainState<T> grainState);
+        void Deserialize<T>(Record record, IGrainState<T> grainState);
     }
 }
-

--- a/src/Orleans.Reminders.Aerospike/AerospikeHostingExtensions.cs
+++ b/src/Orleans.Reminders.Aerospike/AerospikeHostingExtensions.cs
@@ -2,34 +2,11 @@
 using Microsoft.Extensions.Options;
 using Orleans.Hosting;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Orleans.Reminders.Aerospike
 {
     public static class AerospikeHostingExtensions
     {
-        public static ISiloHostBuilder UseAerospikeReminder(this ISiloHostBuilder builder,
-           Action<AerospikeReminderStorageOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAerospikeReminder(configureOptions));
-        }
-
-        public static ISiloHostBuilder UseAerospikeReminder(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<AerospikeReminderStorageOptions>> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAerospikeReminder(configureOptions));
-        }
-
-        public static ISiloHostBuilder UseAerospikeReminder(this ISiloHostBuilder builder)
-        {
-            return builder.ConfigureServices(services =>
-            {
-                services.AddOptions<AerospikeReminderStorageOptions>();
-                services.AddSingleton<IReminderTable, AerospikeReminderTable>();
-            });
-        }
-
         public static ISiloBuilder UseAerospikeReminder(this ISiloBuilder builder,
            Action<AerospikeReminderStorageOptions> configureOptions)
         {

--- a/src/Orleans.Reminders.Aerospike/Orleans.Reminders.Aerospike.csproj
+++ b/src/Orleans.Reminders.Aerospike/Orleans.Reminders.Aerospike.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,9 +21,10 @@
     <Version>1.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
     <PackageReference Include="Aerospike.Client" Version="3.9.10" />
   </ItemGroup>
 

--- a/src/Orleans.Reminders.Aerospike/Orleans.Reminders.Aerospike.csproj
+++ b/src/Orleans.Reminders.Aerospike/Orleans.Reminders.Aerospike.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
-    <PackageReference Include="Aerospike.Client" Version="3.9.10" />
+    <PackageReference Include="Aerospike.Client" Version="4.2.7" />
   </ItemGroup>
 
 </Project>

--- a/test/Orleans.Aerospike.Tests/Grains/TestState.cs
+++ b/test/Orleans.Aerospike.Tests/Grains/TestState.cs
@@ -3,26 +3,27 @@ using System.Collections.Generic;
 
 namespace Orleans.Aerospike.Tests.Grains
 {
+    [Serializable]
+    [GenerateSerializer]
     public class TestState
     {
-        public int NumberInt { get; set; }
-        public long NumberLong { get; set; }
-        public string Text { get; set; }
-        public float NumberFloat { get; set; }
-        public double NumberDouble { get; set; }
-        public DateTime DateTime { get; set; }
-        public Guid Guid { get; set; }
-        public List<string> StringList { get; set; } = new List<string>();
-        public short NumberShort { get; set; }
-        public char Char { get; set; }
-        public byte[] ByteArray { get; set; }
-        public byte Byte { get; set; }
-        public uint NumberUInt { get; set; }
-        public List<int> NumberList { get; set; } = new List<int>();
-        public List<float> FloatList { get; set; } = new List<float>();
-        public Dictionary<string, int> MapStringInt { get; set; }
-
-        public Dictionary<string, TestState> StateInState { get; set; }
+        [Id(0)] public int NumberInt { get; set; }
+        [Id(1)] public long NumberLong { get; set; }
+        [Id(2)] public string Text { get; set; }
+        [Id(3)] public float NumberFloat { get; set; }
+        [Id(4)] public double NumberDouble { get; set; }
+        [Id(5)] public DateTime DateTime { get; set; }
+        [Id(6)] public Guid Guid { get; set; }
+        [Id(7)] public List<string> StringList { get; set; } = new List<string>();
+        [Id(8)] public short NumberShort { get; set; }
+        [Id(9)] public char Char { get; set; }
+        [Id(10)] public byte[] ByteArray { get; set; }
+        [Id(11)] public byte Byte { get; set; }
+        [Id(12)] public uint NumberUInt { get; set; }
+        [Id(13)] public List<int> NumberList { get; set; } = new List<int>();
+        [Id(14)] public List<float> FloatList { get; set; } = new List<float>();
+        [Id(15)] public Dictionary<string, int> MapStringInt { get; set; }
+        [Id(16)] public Dictionary<string, TestState> StateInState { get; set; }
 
         public static TestState CreateTestState()
         {

--- a/test/Orleans.Aerospike.Tests/MBTTests.cs
+++ b/test/Orleans.Aerospike.Tests/MBTTests.cs
@@ -3,9 +3,6 @@ using Microsoft.Extensions.Options;
 using Orleans.Clustering.Aerospike;
 using Orleans.Configuration;
 using Orleans.Messaging;
-using System;
-using System.Collections.ObjectModel;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -35,7 +32,7 @@ namespace Orleans.Aerospike.Tests
                 CleanupOnInit = true,
                 SetName = "OrleansMBRTest"
             };
-            return new AerospikeMembershipTable(this.loggerFactory, Options.Create(new ClusterOptions { ClusterId = this.clusterId }), Options.Create(options));
+            return new AerospikeMembershipTable(this.loggerFactory.CreateLogger<AerospikeMembershipTable>(), Options.Create(new ClusterOptions { ClusterId = this.clusterId }), Options.Create(options));
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
@@ -45,7 +42,7 @@ namespace Orleans.Aerospike.Tests
                 SetName = "OrleansMBRTest"
             };
 
-            return new AerospikeGatewayListProvider(this.loggerFactory,
+            return new AerospikeGatewayListProvider(
                 Options.Create(options),
                 Options.Create(new ClusterOptions { ClusterId = this.clusterId }),
                 Options.Create(new GatewayOptions()));

--- a/test/Orleans.Aerospike.Tests/Orleans.Aerospike.Tests.csproj
+++ b/test/Orleans.Aerospike.Tests/Orleans.Aerospike.Tests.csproj
@@ -1,32 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
+    <OrleansCodeGenLogLevel>Trace</OrleansCodeGenLogLevel>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aerospike.Client" Version="3.9.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="4.0.0-preview1" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="4.0.0-preview1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Aerospike.Tests/OrleansFixture.cs
+++ b/test/Orleans.Aerospike.Tests/OrleansFixture.cs
@@ -29,7 +29,7 @@ namespace Orleans.Aerospike.Tests
             var siloPort = EndpointOptions.DEFAULT_SILO_PORT + portInc;
             var gatewayPort = EndpointOptions.DEFAULT_GATEWAY_PORT + portInc;
             var silo = new HostBuilder()
-                .ConfigureLogging(builder =>  { builder.AddConsole(); })
+                .ConfigureLogging(builder => { builder.AddConsole(); })
                 .UseOrleans(b =>
                 {
                     b.UseLocalhostClustering();
@@ -39,13 +39,11 @@ namespace Orleans.Aerospike.Tests
                         options.ClusterId = ClusterId;
                         options.ServiceId = serviceId;
                     });
-                    //b.ConfigureApplicationParts(pm => pm.AddApplicationPart(typeof(PersistenceTests).Assembly));
                     PreBuild(b);
                 })
                 .Build();
 
             this.Host = silo;
-
             this.Client = this.Host.Services.GetRequiredService<IClusterClient>();
         }
 
@@ -61,7 +59,10 @@ namespace Orleans.Aerospike.Tests
             {
                 await Host.StopAsync();
             }
-            catch { }
+            catch
+            {
+                // ignored
+            }
         }
 
         public async Task DeactivateGrains()

--- a/test/Orleans.Aerospike.Tests/PersistenceOrleansSerializerTests.cs
+++ b/test/Orleans.Aerospike.Tests/PersistenceOrleansSerializerTests.cs
@@ -1,15 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Orleans.Configuration;
+﻿using Microsoft.Extensions.Hosting;
 using Orleans.Hosting;
-using Orleans.TestingHost;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using System.Collections.Generic;
-using Microsoft.VisualBasic.CompilerServices;
-using Orleans.Runtime;
 using Orleans.Persistence.Aerospike.Serializer;
 using Orleans.Aerospike.Tests.Grains;
 
@@ -27,7 +20,7 @@ namespace Orleans.Aerospike.Tests
             }
         }
 
-        private StorageFixture _fixture;
+        private readonly StorageFixture _fixture;
 
         public PersistenceOrleansSerializerTests(StorageFixture fixture) => this._fixture = fixture;
 
@@ -39,7 +32,7 @@ namespace Orleans.Aerospike.Tests
             var testGrain = _fixture.Client.GetGrain<ITestGrain>(grainId);
             var state = TestState.CreateTestState();
             await testGrain.WriteState(state);
-            
+
             await _fixture.DeactivateGrains();
 
             var testGrain2 = _fixture.Client.GetGrain<ITestGrain>(grainId);

--- a/test/Orleans.Aerospike.Tests/PersistencePropertySerializerTests.cs
+++ b/test/Orleans.Aerospike.Tests/PersistencePropertySerializerTests.cs
@@ -1,15 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Orleans.Configuration;
+﻿using Microsoft.Extensions.Hosting;
 using Orleans.Hosting;
-using Orleans.TestingHost;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using System.Collections.Generic;
-using Microsoft.VisualBasic.CompilerServices;
-using Orleans.Runtime;
 using Orleans.Persistence.Aerospike.Serializer;
 using Orleans.Aerospike.Tests.Grains;
 using System.Linq;
@@ -28,7 +21,7 @@ namespace Orleans.Aerospike.Tests
             }
         }
 
-        private StorageFixture _fixture;
+        private readonly StorageFixture _fixture;
 
         public PersistencePropertySerializerTests(StorageFixture fixture) => this._fixture = fixture;
 

--- a/test/Orleans.Aerospike.Tests/ReminderTests.cs
+++ b/test/Orleans.Aerospike.Tests/ReminderTests.cs
@@ -2,8 +2,6 @@
 using Orleans.Hosting;
 using Orleans.Reminders.Aerospike;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,7 +19,7 @@ namespace Orleans.Aerospike.Tests
             }
         }
 
-        private ReminderFixture _fixture;
+        private readonly ReminderFixture _fixture;
 
         public ReminderTests(ReminderFixture fixture)
         {


### PR DESCRIPTION
A port of the current code to Orleans [4.0.0-preview1](https://github.com/dotnet/orleans/releases/tag/v4.0.0-preview1). It would be awesome if we could get this as a prerelease package on NuGet due to the issue described in #2.

Couple of notes:

- Orleans 4 does not support .NET Standard targets anymore, so I added multi-targeting for .NET Core App 3.1, .NET 5 and .NET 6; the test project is .NET 6 now.
- This one also contains the changes in #3 and #4, but I can remove them again if needed.